### PR TITLE
Create dir_workspace_test.py

### DIFF
--- a/torchx/workspace/test/dir_workspace_test.py
+++ b/torchx/workspace/test/dir_workspace_test.py
@@ -48,6 +48,7 @@ class DirWorkspaceTest(unittest.TestCase):
         fs = fsspec.filesystem("memory")
         files = [
             "ignoredir/bar",
+            "ignoredir/recursive/ignorefile",
             "dir1/bar",
             "dir/ignorefileglob1",
             "dir/recursive/ignorefileglob2",


### PR DESCRIPTION
Add a file in subdir of ignoredir to test. This should be ignored (but currently this makes the test fail).
